### PR TITLE
Publish generated MaterialIcon type

### DIFF
--- a/font/package.json
+++ b/font/package.json
@@ -4,7 +4,9 @@
   "description": "Latest icon fonts and CSS for material design icons.",
   "browser": "index.css",
   "sass": "index.scss",
+  "types": "index.d.ts",
   "files": [
+    "index.d.ts",
     "*.{css,scss,woff2}"
   ],
   "scripts": {


### PR DESCRIPTION
Follow up to #12. Publishes the type file generated by `npx @material-design-icons/scripts generate types`